### PR TITLE
perf: eliminate __init__ HTTP fetch and @eval recompilation (~5× faster import)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,3 @@
+update-servers:
+    curl -fsSL https://raw.githubusercontent.com/hapi-server/servers/refs/heads/master/abouts.json \
+        -o src/abouts.json

--- a/src/HAPIClient.jl
+++ b/src/HAPIClient.jl
@@ -11,7 +11,7 @@ using SpaceDataModel: name, units, meta
 import SpaceDataModel: times
 
 export hapi, get_data, meta, times
-export HAPIVariable, HAPIVariables, Server
+export HAPIVariable, HAPIVariables, Server, refresh_servers!
 
 json_parse(x) = JSON.parse(String(x))
 
@@ -41,17 +41,13 @@ hapi(server, dataset, parameters) = get_parameters(server, dataset, parameters)
 hapi(server, dataset, tmin, tmax; kwargs...) = get_data(server, dataset, "", tmin, tmax; kwargs...)
 hapi(server, dataset, parameters, tmin, tmax; kwargs...) = get_data(server, dataset, parameters, tmin, tmax; kwargs...)
 
-function __init__()
-    ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
-    load_servers_from_json(; register = true)
-    return Base.invokelatest(_define_server_constants)
-end
-
-function _define_server_constants()
-    return foreach(values(SERVERS)) do server
-        sym = Symbol(server.id)
-        @eval const $sym = $server
-        @eval export $sym
+# Load bundled server list and define per-server constants at precompile time.
+# Use refresh_servers!() to update from the remote registry at runtime.
+let _servers = load_servers_from_json(; register = true)
+    for _server in _servers
+        _sym = Symbol(_server.id)
+        @eval const $_sym = $_server
+        @eval export $_sym
     end
 end
 

--- a/src/abouts.json
+++ b/src/abouts.json
@@ -1,23 +1,5 @@
 [
   {
-    "x_url": "https://amda.irap.omp.eu/service/hapi",
-    "id": "AMDA",
-    "title": "AMDA",
-    "contact": "Vincent Génot",
-    "contactID": "amda@irap.omp.eu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "ace_r",
-        "start": "2024-01-31T00:00:00Z",
-        "stop": "2024-02-01T00:00:00Z",
-        "parameters": "ace_r"
-      }
-    },
-    "x_LastUpdateAttempt": "2025-05-21T02:52:50Z",
-    "x_LastUpdateError": "<class 'json.decoder.JSONDecodeError'> Expecting value: line 1 column 1 (char 0)"
-  },
-  {
     "x_url": "https://cdaweb.gsfc.nasa.gov/hapi",
     "id": "CDAWeb",
     "title": "CDAWeb",
@@ -32,98 +14,8 @@
         "parameters": "BGSEc"
       }
     },
-    "x_LastUpdateAttempt": "2025-05-21T02:52:50Z",
-    "x_LastUpdateError": "<class 'requests.exceptions.HTTPError'> 400 Client Error: 400 for url: https://cdaweb.gsfc.nasa.gov/hapi/about"
-  },
-  {
-    "x_url": "https://csatools.esac.esa.int/HapiServer/hapi",
-    "id": "CSA",
-    "title": "Cluster Science Archive",
-    "contact": "https://www.cosmos.esa.int/web/csa/cluster-helpdesk",
-    "contactID": "esdc_cluster_logs@cosmos.esa.int",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "C4_PP_FGM",
-        "start": "2020-02-24T11:00Z",
-        "stop": "2020-02-24T12:00Z",
-        "parameters": "B_xyz_gse"
-      }
-    },
-    "x_LastUpdate": "2025-05-21T02:52:51Z",
-    "x_LastUpdateChange": "2025-05-20T13:24:59Z",
-    "HAPI": "3.2",
-    "description": "This HAPI server is based on responses provided by the TAP server at https://csa.esac.esa.int/csa-sl-tap/",
-    "x_hapi_home": "/tmp/hapi-server/",
-    "x_buildTime": "2024-03-12T07:42:00",
-    "status": {
-      "code": 1200,
-      "message": "OK request successful"
-    }
-  },
-  {
-    "x_url": "https://iswa.gsfc.nasa.gov/IswaSystemWebApp/hapi",
-    "id": "CCMC_ISWA",
-    "title": "CCMC ISWA",
-    "contact": "Rick Mullinix",
-    "contactID": "richard.e.mullinix@nasa.gov",
-    "x_LastUpdateAttempt": "2025-05-21T02:52:51Z",
-    "x_LastUpdateError": "<class 'requests.exceptions.HTTPError'> 404 Client Error: Not Found for url: https://iswa.gsfc.nasa.gov/IswaSystemWebApp/hapi/about"
-  },
-  {
-    "x_url": "http://lasp.colorado.edu/lisird/hapi",
-    "id": "LISIRD",
-    "title": "LISIRD",
-    "contact": "Doug Lindholm",
-    "contactID": "Doug.Lindholm@lasp.colorado.edu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "composite_mg_index",
-        "start": "2013-07-10Z",
-        "stop": "2013-07-18Z",
-        "parameters": "mg_index"
-      }
-    },
-    "x_LastUpdateAttempt": "2025-05-21T02:52:51Z",
-    "x_LastUpdateError": "<class 'requests.exceptions.HTTPError'> 404 Client Error: Not Found for url: https://lasp.colorado.edu/lisird/hapi/about"
-  },
-  {
-    "x_url": "https://imag-data.bgs.ac.uk/GIN_V1/hapi",
-    "id": "INTERMAGNET",
-    "title": "INTERMAGNET HAPI server",
-    "contact": "e_ginman@bgs.ac.uk",
-    "contactID": "e_ginman@bgs.ac.uk",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "aae/definitive/PT1M/native",
-        "start": "2013-12-31Z",
-        "stop": "2014-01-01Z",
-        "parameters": "Field_Magnitude"
-      }
-    },
-    "x_LastUpdate": "2025-05-21T02:52:52Z",
-    "x_LastUpdateChange": "2025-05-20T13:25:00Z",
-    "HAPI": "3.1",
-    "description": "For more information see intermagnet.org",
-    "citation": "https://intermagnet.org/data_conditions.html",
-    "x_warnings": [
-      "Data providers may embargo data. For details see https://imag-data.bgs.ac.uk/GIN_V1/GINForms2?request=ShowObservatoryDetails"
-    ],
-    "status": {
-      "code": 1200,
-      "message": "ok"
-    }
-  },
-  {
-    "x_url": "https://api.helioviewer.org/hapi/Helioviewer/hapi",
-    "id": "Helioviewer",
-    "title": "Helioviewer",
-    "contact": "Daniel Garcia Briseno",
-    "contactID": "daniel.garciabriseno@nasa.gov",
-    "x_LastUpdateAttempt": "2025-05-21T02:52:52Z",
-    "x_LastUpdateError": "<class 'requests.exceptions.HTTPError'> 404 Client Error: Not Found for url: https://api.helioviewer.org/hapi/Helioviewer/hapi/about"
+    "x_LastUpdateAttempt": "2026-05-13T15:05:07Z",
+    "x_LastUpdateError": "400 Client Error: 400 for url: https://cdaweb.gsfc.nasa.gov/hapi/about"
   },
   {
     "x_url": "http://hapi-server.org/servers/SSCWeb/hapi",
@@ -140,8 +32,60 @@
         "parameters": "X_GSE,Y_GSE,Z_GSE"
       }
     },
-    "x_LastUpdateAttempt": "2025-05-21T02:52:52Z",
-    "x_LastUpdateError": "<class 'requests.exceptions.HTTPError'> 404 Client Error: Not Found for url: http://hapi-server.org/servers/SSCWeb/hapi/about"
+    "x_LastUpdateAttempt": "2026-05-13T15:05:07Z",
+    "x_LastUpdateError": "404 Client Error: Not Found for url: http://hapi-server.org/servers/SSCWeb/hapi/about"
+  },
+  {
+    "x_url": "https://amda.irap.omp.eu/service/hapi",
+    "id": "AMDA",
+    "title": "AMDA",
+    "contact": "Vincent Génot",
+    "contactID": "amda@irap.omp.eu",
+    "dataTest": {
+      "name": "Ping Test",
+      "query": {
+        "dataset": "ace_r",
+        "start": "2024-01-31T00:00:00Z",
+        "stop": "2024-02-01T00:00:00Z",
+        "parameters": "ace_r"
+      }
+    },
+    "x_LastUpdateAttempt": "2026-05-13T15:05:08Z",
+    "x_LastUpdateError": "Expecting value: line 1 column 1 (char 0)"
+  },
+  {
+    "x_url": "https://csatools.esac.esa.int/HapiServer/hapi",
+    "id": "CSA",
+    "title": "Cluster Science Archive",
+    "contact": "https://www.cosmos.esa.int/web/csa/cluster-helpdesk",
+    "contactID": "esdc_cluster_logs@cosmos.esa.int",
+    "dataTest": {
+      "name": "Ping Test",
+      "query": {
+        "dataset": "C4_PP_FGM",
+        "start": "2020-02-24T11:00Z",
+        "stop": "2020-02-24T12:00Z",
+        "parameters": "B_xyz_gse"
+      }
+    },
+    "HAPI": "3.2",
+    "description": "This HAPI server is based on responses provided by the TAP server at https://csa.esac.esa.int/csa-sl-tap/",
+    "x_hapi_home": "/tmp/hapi-server/",
+    "status": {
+      "code": 1200,
+      "message": "OK request successful"
+    },
+    "x_buildTime": "2024-03-12T07:42:00",
+    "x_LastUpdateAttempt": "2026-05-13T15:05:09Z"
+  },
+  {
+    "x_url": "https://iswa.gsfc.nasa.gov/IswaSystemWebApp/hapi",
+    "id": "CCMC_ISWA",
+    "title": "CCMC ISWA",
+    "contact": "Rick Mullinix",
+    "contactID": "richard.e.mullinix@nasa.gov",
+    "x_LastUpdateAttempt": "2026-05-13T15:05:09Z",
+    "x_LastUpdateError": "404 Client Error: Not Found for url: https://iswa.gsfc.nasa.gov/IswaSystemWebApp/hapi/about"
   },
   {
     "x_url": "https://vires.services/hapi",
@@ -158,39 +102,58 @@
         "parameters": "F"
       }
     },
-    "x_LastUpdate": "2025-05-21T02:52:52Z",
-    "x_LastUpdateChange": "2025-05-20T13:25:01Z",
-    "HAPI": "3.0",
     "description": "Web API for the ESA Swarm mission products.",
+    "HAPI": "3.0",
     "status": {
       "code": 1200,
       "message": "OK"
-    }
+    },
+    "x_LastUpdateAttempt": "2026-05-13T15:05:09Z"
   },
   {
-    "x_url": "https://hapi.spaceweather.knmi.nl/hapi",
-    "id": "KNMI",
-    "title": "KNMI public HAPI server for use with the space weather timeline viewer",
-    "contact": "Eelco Doornbos",
-    "contactID": "eelco.doornbos@knmi.nl",
+    "x_url": "https://imag-data.bgs.ac.uk/GIN_V1/hapi",
+    "id": "INTERMAGNET",
+    "title": "INTERMAGNET HAPI server",
+    "contact": "e_ginman@bgs.ac.uk",
+    "contactID": "e_ginman@bgs.ac.uk",
     "dataTest": {
       "name": "Ping Test",
       "query": {
-        "dataset": "champ_thermosphere_density",
-        "start": "2000-07-31T00:00:00.000000Z",
-        "stop": "2000-08-02T00:00:00.000Z",
-        "parameters": "density"
+        "dataset": "aae/definitive/PT1M/native",
+        "start": "2013-12-31Z",
+        "stop": "2014-01-01Z",
+        "parameters": "Field_Magnitude"
       }
     },
-    "x_LastUpdate": "2025-05-21T02:52:53Z",
-    "x_LastUpdateChange": "2025-05-20T13:25:01Z",
-    "description": "Data on this server has been obtained from a variety of sources, and reproduced based on open licenses and/or with express permission of the data owners. It is intended for quick-look visualization with the space weather timeline viewer only. For further analysis, users are advised to retrieve copies of the data from the data owner's repositories.",
-    "citation": "",
     "HAPI": "3.1",
+    "description": "This HAPI server provides datasets with IDs in the form IAGACode/DataType/Cadence/Components. IAGACode is the three-letter IAGA code (https://iaga-vobs.org/) for the observatory. DataType is one of: 'adjusted', 'definitive', 'quasi-def', 'reported' (https://tech-man.intermagnet.org/stable/appendices/terminology.html) or 'best-avail' for the best available data. See https://imag-data.bgs.ac.uk/GIN_V1/index.jsp#best_avail for a discussion of what 'best-avail' implies. Cadence is an ISO8601 duration. This server only offers minute ('PT1M') and second ('PT1S') cadence data. Components is one of: 'xyzf', 'hdzf', 'diff' (https://intermagnet.org/faq/10.geomagnetic-comp.html) or 'native' to use the components that the data provider sent the data in.",
+    "citation": "https://intermagnet.org/data_conditions.html",
+    "x_warnings": [
+      "Some institutes choose to embargo their data for a short time. For more information see https://imag-data.bgs.ac.uk/GIN_V1/index.jsp#embargo_data_plots"
+    ],
     "status": {
       "code": 1200,
-      "message": "HAPI 1200: OK"
-    }
+      "message": "ok"
+    },
+    "x_LastUpdateAttempt": "2026-05-13T15:05:10Z"
+  },
+  {
+    "x_url": "https://supermag.jhuapl.edu/hapi",
+    "id": "SuperMAG",
+    "title": "SuperMAG (dev version)",
+    "contact": "Sandy Antunes",
+    "contactID": "Sandy.Antunes@jhuapl.edu",
+    "dataTest": {
+      "name": "Ping Test",
+      "query": {
+        "dataset": "indices_all",
+        "start": "2018-01-18T00:00Z",
+        "stop": "2018-01-19T00:00Z",
+        "parameters": "SML"
+      }
+    },
+    "x_LastUpdateAttempt": "2026-05-13T15:05:10Z",
+    "x_LastUpdateError": "404 Client Error: Not Found for url: https://supermag.jhuapl.edu/hapi/about"
   },
   {
     "x_url": "https://wdcapi.bgs.ac.uk/hapi",
@@ -207,14 +170,64 @@
         "parameters": "Field_Vector"
       }
     },
-    "x_LastUpdate": "2025-05-21T02:52:54Z",
-    "x_LastUpdateChange": "2025-05-20T13:25:02Z",
     "HAPI": "3.2",
-    "description": "Web API for the WDC at Edinburgh datasets. Data is offered at cadences of: minute, hour, day, month and year. K-index data is also available. Data are delivered on a best-quality basis, and converted on-the-fly to the requested orientation and file format. All data are definitive.",
     "status": {
       "code": 1200,
       "message": "OK"
-    }
+    },
+    "description": "Web API for the WDC at Edinburgh datasets. Data is offered at cadences of: minute, hour, day, month and year. K-index data is also available. Data are delivered on a best-quality basis, and converted on-the-fly to the requested orientation and file format. All data are definitive.",
+    "x_LastUpdateAttempt": "2026-05-13T15:05:10Z"
+  },
+  {
+    "x_url": "http://lasp.colorado.edu/lisird/hapi",
+    "id": "LISIRD",
+    "title": "LISIRD",
+    "contact": "Doug Lindholm",
+    "contactID": "Doug.Lindholm@lasp.colorado.edu",
+    "dataTest": {
+      "name": "Ping Test",
+      "query": {
+        "dataset": "composite_mg_index",
+        "start": "2013-07-10Z",
+        "stop": "2013-07-18Z",
+        "parameters": "mg_index"
+      }
+    },
+    "x_LastUpdateAttempt": "2026-05-13T15:05:11Z",
+    "x_LastUpdateError": "404 Client Error: Not Found for url: https://lasp.colorado.edu/lisird/hapi/about"
+  },
+  {
+    "x_url": "https://hapi.spaceweather.knmi.nl/hapi",
+    "id": "KNMI",
+    "title": "KNMI public HAPI server for use with the space weather timeline viewer",
+    "contact": "Eelco Doornbos",
+    "contactID": "eelco.doornbos@knmi.nl",
+    "dataTest": {
+      "name": "Ping Test",
+      "query": {
+        "dataset": "champ_thermosphere_density",
+        "start": "2000-07-31T00:00:00.000000Z",
+        "stop": "2000-08-02T00:00:00.000Z",
+        "parameters": "density"
+      }
+    },
+    "description": "Data on this server has been obtained from a variety of sources, and reproduced based on open licenses and/or with express permission of the data owners. It is intended for quick-look visualization with the space weather timeline viewer only. For further analysis, users are advised to retrieve copies of the data from the data owner's repositories.",
+    "citation": "",
+    "HAPI": "3.1",
+    "status": {
+      "code": 1200,
+      "message": "HAPI 1200: OK"
+    },
+    "x_LastUpdateAttempt": "2026-05-13T15:05:11Z"
+  },
+  {
+    "x_url": "https://api.helioviewer.org/hapi/Helioviewer/hapi",
+    "id": "Helioviewer",
+    "title": "Helioviewer",
+    "contact": "Daniel Garcia Briseno",
+    "contactID": "daniel.garciabriseno@nasa.gov",
+    "x_LastUpdateAttempt": "2026-05-13T15:05:11Z",
+    "x_LastUpdateError": "404 Client Error: Not Found for url: https://api.helioviewer.org/hapi/Helioviewer/hapi/about"
   },
   {
     "x_url": "https://planet.physics.uiowa.edu/das/das2Server/hapi",
@@ -231,144 +244,7 @@
         "parameters": "B_mag"
       }
     },
-    "x_LastUpdateAttempt": "2025-05-21T02:52:54Z",
-    "x_LastUpdateError": "<class 'json.decoder.JSONDecodeError'> Expecting value: line 1 column 1 (char 0)"
-  },
-  {
-    "x_url": "http://hapi-server.org/servers/TestData2.0/hapi",
-    "id": "TestData2.0",
-    "title": "HAPI 2.0 Test Data",
-    "description": "Server for testing clients on HAPI 2.0 features",
-    "contact": "Bob Weigel",
-    "contactID": "rweigel@gmu.edu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "dataset1",
-        "start": "1970-01-01T00:00:00Z",
-        "stop": "1970-01-01T00:00:40Z",
-        "parameters": "scalar"
-      }
-    },
-    "x_LastUpdateAttempt": "2025-05-21T02:52:54Z",
-    "x_LastUpdateError": "<class 'requests.exceptions.HTTPError'> 404 Client Error: Not Found for url: http://hapi-server.org/servers/TestData2.0/hapi/about"
-  },
-  {
-    "x_url": "http://hapi-server.org/servers/TestData2.1/hapi",
-    "id": "TestData2.1",
-    "title": "HAPI 2.1 Test Data",
-    "description": "Server for testing clients with HAPI 2.1 additions",
-    "contact": "Bob Weigel",
-    "contactID": "rweigel@gmu.edu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "dataset1",
-        "start": "1970-01-01T00:00:00Z",
-        "stop": "1970-01-01T00:00:40Z",
-        "parameters": "vectorstring"
-      }
-    },
-    "x_LastUpdateAttempt": "2025-05-21T02:52:54Z",
-    "x_LastUpdateError": "<class 'requests.exceptions.HTTPError'> 404 Client Error: Not Found for url: http://hapi-server.org/servers/TestData2.1/hapi/about"
-  },
-  {
-    "x_url": "http://hapi-server.org/servers/TestData3.0/hapi",
-    "id": "TestData3.0",
-    "title": "Server using HAPI 3.0 additions",
-    "description": "Server for testing clients with HAPI 3.0 additions",
-    "contact": "rweigel@gmu.edu",
-    "contactID": "rweigel@gmu.edu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "spectra_time_dependent_bins",
-        "start": "1970-01-01T00:00:00Z",
-        "stop": "1970-01-01T00:00:40Z",
-        "parameters": "scalar"
-      }
-    },
-    "x_LastUpdate": "2025-05-21T02:52:54Z",
-    "x_LastUpdateChange": "2025-05-20T13:25:02Z",
-    "HAPI": "3.0",
-    "status": {
-      "code": 1200,
-      "message": "OK"
-    }
-  },
-  {
-    "x_url": "http://hapi-server.org/servers/TestData3.1/hapi",
-    "id": "TestData3.1",
-    "title": "Server using HAPI 3.1 additions",
-    "description": "Server for testing clients with HAPI 3.1 additions",
-    "contact": "rweigel@gmu.edu",
-    "contactID": "rweigel@gmu.edu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "unicodevector (Z;α;☃;👍)",
-        "start": "1970-01-01T00:00:00Z",
-        "stop": "1970-01-01T00:00:40Z",
-        "parameters": "scalar"
-      }
-    },
-    "x_LastUpdate": "2025-05-21T02:52:54Z",
-    "x_LastUpdateChange": "2025-05-20T13:25:02Z",
-    "HAPI": "3.1",
-    "status": {
-      "code": 1200,
-      "message": "OK"
-    }
-  },
-  {
-    "x_url": "http://hapi-server.org/servers/TestData3.2/hapi",
-    "id": "TestData3.2",
-    "title": "Server using HAPI 3.2 additions",
-    "description": "Server for testing clients with HAPI 3.2 additions",
-    "contact": "rweigel@gmu.edu",
-    "contactID": "rweigel@gmu.edu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "DE1/PWI/B_H",
-        "start": "1981-09-16T02:19Z",
-        "stop": "1981-09-17T19:24Z",
-        "parameters": "scalar"
-      }
-    },
-    "x_LastUpdate": "2025-05-21T02:52:54Z",
-    "x_LastUpdateChange": "2025-05-20T13:25:02Z",
-    "HAPI": "3.2",
-    "status": {
-      "code": 1200,
-      "message": "OK"
-    }
-  },
-  {
-    "x_url": "http://hapi-server.org/servers/TestData3.3/hapi",
-    "id": "TestData3.3",
-    "title": "Server using HAPI 3.3 additions",
-    "description": "Server for testing clients with HAPI 3.3 additions",
-    "contact": "rweigel@gmu.edu",
-    "contactID": "rweigel@gmu.edu",
-    "dataTest": {
-      "name": "Ping Test",
-      "query": {
-        "dataset": "DE1/PWI/B_H",
-        "start": "1970-01-01T00:00:00Z",
-        "stop": "1970-01-01T00:00:20Z",
-        "parameters": "vector"
-      }
-    },
-    "x_LastUpdate": "2025-05-21T02:52:54Z",
-    "x_LastUpdateChange": "2025-05-20T13:36:47Z",
-    "serverCitation": "DOI",
-    "note": ["note 1", "note 2"],
-    "warning": ["warning 1", "warning 2"],
-    "HAPI": "3.3",
-    "status": {
-      "code": 1200,
-      "message": "OK"
-    }
+    "x_LastUpdateAttempt": "2026-05-13T15:05:12Z",
+    "x_LastUpdateError": "Expecting value: line 1 column 1 (char 0)"
   }
 ]

--- a/src/server.jl
+++ b/src/server.jl
@@ -52,21 +52,17 @@ function get_capabilities(server)
 end
 
 """
-    load_servers_from_json(; url=DEFAULT_SERVERS_JSON_URL, register=false)
+    load_servers_from_json(source=joinpath(@__DIR__, "abouts.json"); register=false)
 
-Load HAPI servers from a JSON file at the specified URL.
+Load HAPI servers from a local JSON file or remote URL.
 """
-function load_servers_from_json(; url = DEFAULT_SERVERS_JSON_URL, register = false)
-    # Fetch the JSON data: try to load from URL first, fall back to file if HTTP fails
-    servers_data = try
-        response = HTTP.get(url)
-        json_parse(response.body)
-    catch
-        @warn "HTTP request failed, falling back to local file"
-        JSON.parsefile(joinpath(@__DIR__, "abouts.json"))
+function load_servers_from_json(source = joinpath(@__DIR__, "abouts.json"); register = false)
+    servers_data = if startswith(string(source), "http")
+        json_parse(HTTP.get(source).body)
+    else
+        JSON.parsefile(source)
     end
 
-    # Register each server
     servers = map(servers_data) do server_info
         Server(
             url = server_info["x_url"],
@@ -80,4 +76,13 @@ function load_servers_from_json(; url = DEFAULT_SERVERS_JSON_URL, register = fal
     register && register_server!.(servers)
 
     return servers
+end
+
+"""
+    refresh_servers!(; url=DEFAULT_SERVERS_JSON_URL)
+
+Fetch the latest server list from the remote URL and update the registry.
+"""
+function refresh_servers!(; url = DEFAULT_SERVERS_JSON_URL)
+    return load_servers_from_json(url; register = true)
 end


### PR DESCRIPTION
## Summary

- Remove `__init__()` HTTP fetch to GitHub on every import (~1s network call)
- Move `@eval const` server constant definitions from `__init__` to module top-level so they run once at precompile time (eliminating 91% recompilation on load)
- Default `load_servers_from_json` to bundled `src/abouts.json` instead of remote URL
- Add `refresh_servers!()` for explicit network updates
- Add `justfile` with `update-servers` recipe to pull latest `abouts.json` from upstream

## Result

```
Before: 1530ms, 68% compilation (79% recompilation)
After:   300ms,  8% compilation
```